### PR TITLE
feat(waffler controller): Make source/parse a WebSocket 

### DIFF
--- a/internal/modules/message/message.go
+++ b/internal/modules/message/message.go
@@ -31,6 +31,7 @@ type ParserRequest struct {
 	SourceURL string           `json:"source_url"`
 	ScoreType models.ScoreType `json:"score_type"`
 	Parser    *Parser          `json:"parser"`
+	Limit     int              `json:"limit"`
 	ClientID  string           `json:"client_id"`
 }
 

--- a/internal/modules/waffler/service/service.go
+++ b/internal/modules/waffler/service/service.go
@@ -329,7 +329,7 @@ func (w *WafflerService) parseSourceTypeWaffler(search *message.ParserRequest, d
 					if score.Int64 < 0 {
 						score = models.NullInt64{}
 					}
-					newWafflerRecords.records = append(newWafflerRecords, models.WafflerDTO{
+					newWafflerRecords.records = append(newWafflerRecords.records, models.WafflerDTO{
 						Score:           score,
 						ParserType:      models.GPT3_5TURBO,
 						RecordIDBefore:  r.ID,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -36,7 +36,7 @@ func NewApiRouter(controllers *modules.Controllers, components *component.Compon
 	r.Route("/source", func(r chi.Router) {
 		sourceController := controllers.Waffler
 		r.Post("/search", sourceController.Search)
-		r.Post("/parse", sourceController.Parse)
+		r.HandleFunc("/parse", sourceController.Parse)
 		r.HandleFunc("/ws", sourceController.WsTest)
 		r.Post("/score", sourceController.Score)
 		r.Post("/info", sourceController.Info)


### PR DESCRIPTION
Fixed a thread-safety issue in waffler service.

Added field Limit to ParserRequest.

Changed Post route to HandleFunc in router for /source/parse to support websockets.

Modified WafflerService ParseSource to write to channel updateChan whenever a record is processed.

Modified Waffl Parse to upgrade connection to websocket.
Handler now reads request data from websocket connection.
Handler writes to client updated progress each time a record is processed.