### PR TITLE
feat(waffler): Change scores to Nullable types

### DIFF
--- a/internal/infrastructure/db/db.go
+++ b/internal/infrastructure/db/db.go
@@ -53,15 +53,72 @@ func TestDB(conn *gorm.DB) error {
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 20; i++ {
 			sourceNew := &models.SourceDTO{
 				Name:         gofakeit.BeerName(),
 				SourceType:   models.SourceType(gofakeit.Number(0, 1)),
 				SourceUrl:    gofakeit.URL(),
-				WafflerScore: gofakeit.Float64Range(0, 100),
-				RacismScore:  gofakeit.Float64Range(0, 100),
+				WafflerScore: models.NewNullFloat64(gofakeit.Float64Range(0, 100)),
+				RacismScore:  models.NewNullFloat64(gofakeit.Float64Range(0, 100)),
 			}
 			result = conn.Create(sourceNew)
+			if result.Error != nil {
+				return result.Error
+			}
+
+		}
+		for i := 0; i < 20; i++ {
+			sourceNew := &models.SourceDTO{
+				Name:         gofakeit.BeerName(),
+				SourceType:   models.SourceType(gofakeit.Number(0, 1)),
+				SourceUrl:    gofakeit.URL(),
+				WafflerScore: models.NewNullFloat64(gofakeit.Float64Range(0, 100)),
+			}
+			result = conn.Create(sourceNew)
+			if result.Error != nil {
+				return result.Error
+			}
+
+		}
+		for i := 0; i < 20; i++ {
+			sourceNew := &models.SourceDTO{
+				Name:        gofakeit.BeerName(),
+				SourceType:  models.SourceType(gofakeit.Number(0, 1)),
+				SourceUrl:   gofakeit.URL(),
+				RacismScore: models.NewNullFloat64(gofakeit.Float64Range(0, 100)),
+			}
+			result = conn.Create(sourceNew)
+			if result.Error != nil {
+				return result.Error
+			}
+
+		}
+	}
+
+	racism := &models.RacismDTO{}
+	result = conn.Find(racism)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		for i := 0; i < 10; i++ {
+			racismNew := &models.RacismDTO{
+				SourceID: gofakeit.Number(1, 3),
+			}
+
+			result = conn.Create(racismNew)
+			if result.Error != nil {
+				return result.Error
+			}
+
+		}
+		for i := 0; i < 10; i++ {
+			racismNew := &models.RacismDTO{
+				SourceID: gofakeit.Number(1, 3),
+				Score:    models.NewNullInt64(int64(gofakeit.Number(0, 100))),
+			}
+
+			result = conn.Create(racismNew)
 			if result.Error != nil {
 				return result.Error
 			}

--- a/internal/models/null.go
+++ b/internal/models/null.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"database/sql"
+	"encoding/json"
+)
+
+func NewNullFloat64(f float64) NullFloat64 {
+	var nf NullFloat64
+	nf.Valid = true
+	nf.Float64 = f
+	return nf
+}
+
+type NullFloat64 struct {
+	sql.NullFloat64
+}
+
+func (nf NullFloat64) MarshalJSON() ([]byte, error) {
+	if nf.Valid {
+		return json.Marshal(nf.Float64)
+	}
+	return json.Marshal(nil)
+}
+
+func (nf *NullFloat64) UnmarshalJSON(data []byte) error {
+	var f *float64
+	if err := json.Unmarshal(data, &f); err != nil {
+		return err
+	}
+	if f != nil {
+		nf.Valid = true
+		nf.Float64 = *f
+	} else {
+		nf.Valid = false
+	}
+	return nil
+}
+
+func NewNullInt64(i int64) NullInt64 {
+	var ni NullInt64
+	ni.Valid = true
+	ni.Int64 = i
+	return ni
+}
+
+type NullInt64 struct {
+	sql.NullInt64
+}
+
+func (nf NullInt64) MarshalJSON() ([]byte, error) {
+	if nf.Valid {
+		return json.Marshal(nf.Int64)
+	}
+	return json.Marshal(nil)
+}
+
+func (nf *NullInt64) UnmarshalJSON(data []byte) error {
+	var i *int64
+	if err := json.Unmarshal(data, &i); err != nil {
+		return err
+	}
+	if i != nil {
+		nf.Valid = true
+		nf.Int64 = *i
+	} else {
+		nf.Valid = false
+	}
+	return nil
+}

--- a/internal/models/shema.go
+++ b/internal/models/shema.go
@@ -11,12 +11,12 @@ type UserDTO struct {
 }
 
 type SourceDTO struct {
-	ID           int        `json:"id,omitempty" gorm:"primaryKey"`
-	Name         string     `json:"name"`
-	SourceType   SourceType `json:"source_type"`
-	SourceUrl    string     `json:"source_url"`
-	WafflerScore float64    `json:"waffler_score"`
-	RacismScore  float64    `json:"racism_score"`
+	ID           int         `json:"id,omitempty" gorm:"primaryKey"`
+	Name         string      `json:"name"`
+	SourceType   SourceType  `json:"source_type"`
+	SourceUrl    string      `json:"source_url"`
+	WafflerScore NullFloat64 `json:"waffler_score"`
+	RacismScore  NullFloat64 `json:"racism_score"`
 }
 
 type RecordDTO struct {
@@ -30,7 +30,7 @@ type RecordDTO struct {
 
 type WafflerDTO struct {
 	ID              int        `json:"id,omitempty" gorm:"primaryKey"`
-	Score           int        `json:"score"`
+	Score           NullInt64  `json:"score"`
 	ParserType      ParserType `json:"parser"`
 	RecordIDBefore  int        `json:"record_id_before"`
 	RecordIDAfter   int        `json:"record_id_after"`
@@ -41,7 +41,7 @@ type WafflerDTO struct {
 
 type RacismDTO struct {
 	ID         int        `json:"id,omitempty" gorm:"primaryKey"`
-	Score      int        `json:"score"`
+	Score      NullInt64  `json:"score"`
 	ParserType ParserType `json:"score_type"`
 	CreatedTs  time.Time  `json:"created_ts"`
 	RecordID   int        `json:"record_id"`

--- a/internal/modules/waffler/service/average_test.go
+++ b/internal/modules/waffler/service/average_test.go
@@ -16,78 +16,89 @@ func TestAverageRacismScore(t *testing.T) {
 		records []models.RacismDTO
 		score   float64
 	}{
-		{score: 0, records: []models.RacismDTO{{}}},
-		{score: 10, records: []models.RacismDTO{{CreatedTs: time.Now(), Score: 10}}},
-		{score: 10, records: []models.RacismDTO{{CreatedTs: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 10}}},
+		{score: 0, records: []models.RacismDTO{{Score: models.NewNullInt64(0)}}},
+		{score: 10, records: []models.RacismDTO{{CreatedTs: time.Now(), Score: models.NewNullInt64(10)}}},
+		{score: 10, records: []models.RacismDTO{{CreatedTs: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)}}},
 		{score: 1.368, records: []models.RacismDTO{
-			{CreatedTs: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 10},
-			{CreatedTs: time.Now(), Score: 0},
+			{CreatedTs: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)},
+			{CreatedTs: time.Now(), Score: models.NewNullInt64(0)},
 		}},
 		{score: 1.368, records: []models.RacismDTO{
-			{CreatedTs: time.Now().Add(-20 * time.Millisecond * time.Duration(year)), Score: 10},
-			{CreatedTs: time.Now(), Score: 0},
+			{CreatedTs: time.Now().Add(-20 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)},
+			{CreatedTs: time.Now(), Score: models.NewNullInt64(0)},
 		}},
 		{score: 94.786, records: []models.RacismDTO{
-			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: 100},
-			{CreatedTs: time.Now(), Score: 0},
+			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(100)},
+			{CreatedTs: time.Now(), Score: models.NewNullInt64(0)},
 		}},
 		{score: 67.738, records: []models.RacismDTO{
-			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: 78},
-			{CreatedTs: time.Now(), Score: 0},
+			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(78)},
+			{CreatedTs: time.Now(), Score: models.NewNullInt64(0)},
 		}},
 		{score: 61.050, records: []models.RacismDTO{
-			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: 78},
-			{CreatedTs: time.Now(), Score: 24},
+			{CreatedTs: time.Now().Add(-5 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(78)},
+			{CreatedTs: time.Now(), Score: models.NewNullInt64(24)},
 		}},
+		{score: 0, records: []models.RacismDTO{{}}},
+		{score: 10, records: []models.RacismDTO{{CreatedTs: time.Now(), Score: models.NewNullInt64(10)}, {}}},
 	}
 	for count, tt := range testData {
 		t.Run(fmt.Sprint("test ", count), func(t *testing.T) {
 			score := averageRacismScore(tt.records)
-			assert.InDelta(t, tt.score, score, accuracy)
+			assert.InDelta(t, tt.score, score.Float64, accuracy)
 		})
 	}
+
+	score := averageRacismScore([]models.RacismDTO{{CreatedTs: time.Now()}})
+	assert.Equal(t, false, score.Valid)
 }
+
 func TestAverageWafflerScore(t *testing.T) {
 	testData := []struct {
 		records []models.WafflerDTO
 		score   float64
 	}{
-		{score: 0, records: []models.WafflerDTO{{}}},
-		{score: 10, records: []models.WafflerDTO{{CreatedTsAfter: time.Now(), Score: 10}}},
-		{score: 10, records: []models.WafflerDTO{{CreatedTsAfter: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 10}}},
+		{score: 0, records: []models.WafflerDTO{{Score: models.NewNullInt64(0)}}},
+		{score: 10, records: []models.WafflerDTO{{CreatedTsAfter: time.Now(), Score: models.NewNullInt64(10)}}},
+		{score: 10, records: []models.WafflerDTO{{CreatedTsAfter: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)}}},
 		{score: 6.131, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), Score: 10},
-			{CreatedTsAfter: time.Now(), Score: 0},
+			{CreatedTsAfter: time.Now(), Score: models.NewNullInt64(10)},
+			{CreatedTsAfter: time.Now(), Score: models.NewNullInt64(0)},
 		}},
 		{score: 6.131, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 10},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 0},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(0)},
 		}},
 		{score: 6.131, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-20 * time.Millisecond * time.Duration(year)), Score: 10},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 0},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-20 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(0)},
 		}},
 		{score: 5.284, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 10},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: 0},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(10)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: models.NewNullInt64(0)},
 		}},
 		{score: 98.605, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 100},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: 0},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(100)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: models.NewNullInt64(0)},
 		}},
 		{score: 75.075, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 78},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: 0},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(78)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: models.NewNullInt64(0)},
 		}},
 		{score: 72.316, records: []models.WafflerDTO{
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: 78},
-			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: 24},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-10 * time.Millisecond * time.Duration(year)), Score: models.NewNullInt64(78)},
+			{CreatedTsAfter: time.Now(), CreatedTsBefore: time.Now().Add(-time.Millisecond * time.Duration(40*year/9)), Score: models.NewNullInt64(24)},
 		}},
+		{score: 0, records: []models.WafflerDTO{{}}},
+		{score: 10, records: []models.WafflerDTO{{CreatedTsAfter: time.Now(), Score: models.NewNullInt64(10)}, {}}},
 	}
 	for count, tt := range testData {
 		t.Run(fmt.Sprint("test ", count), func(t *testing.T) {
 			score := averageWafflerScore(tt.records)
-			assert.InDelta(t, tt.score, score, accuracy)
+			assert.InDelta(t, tt.score, score.Float64, accuracy)
 		})
 	}
+
+	score := averageWafflerScore([]models.WafflerDTO{{CreatedTsAfter: time.Now()}})
+	assert.Equal(t, false, score.Valid)
 }

--- a/internal/modules/waffler/service/service.go
+++ b/internal/modules/waffler/service/service.go
@@ -66,7 +66,7 @@ func (u *WafflerService) Score(request *message.ScoreRequest) (*message.ScoreRes
 		for i := range racismRecords {
 			scoreResponse.Records = append(scoreResponse.Records, message.Record{
 				RecordText: records[i].RecordText,
-				Score:      racismRecords[i].Score,
+				Score:      int(racismRecords[i].Score.Int64),
 				Timestamp:  racismRecords[i].CreatedTs,
 			})
 		}
@@ -126,8 +126,12 @@ func (w *WafflerService) parseSourceTypeRacism(search *message.ParserRequest, da
 			var err error
 			res, err := lanModel.ConstructQuestionGPT(tempRecord.RecordText, search.ScoreType)
 			if res != nil {
+				score := models.NewNullInt64(int64(*res))
+				if score.Int64 < 0 {
+					score = models.NullInt64{}
+				}
 				newRacismRecords = append(newRacismRecords, models.RacismDTO{
-					Score:      *res,
+					Score:      score,
 					ParserType: models.GPT3_5TURBO,
 					CreatedTs:  tempRecord.CreatedTs,
 					RecordID:   tempRecord.ID,
@@ -310,8 +314,12 @@ func (w *WafflerService) parseSourceTypeWaffler(search *message.ParserRequest, d
 				var err error
 				res, err := lanModel.ConstructQuestionGPT(text, search.ScoreType)
 				if res != nil {
+					score := models.NewNullInt64(int64(*res))
+					if score.Int64 < 0 {
+						score = models.NullInt64{}
+					}
 					newWafflerRecords = append(newWafflerRecords, models.WafflerDTO{
-						Score:           *res,
+						Score:           score,
 						ParserType:      models.GPT3_5TURBO,
 						RecordIDBefore:  tempRecord.ID,
 						RecordIDAfter:   tempRecord2.ID,


### PR DESCRIPTION
Added nullable types in null.go based of sql Null types. Added methods so that these methods behave the same as base type when marshalling to JSON.

Updated schema.go to use nullable types for scores.

Updated db.go to generate test data with null scores.

Updated service.go to use updated schema and to set scores to null instead of -1 when gpt fails.

Updated average.go to skip null values and return null if no valid values found.

Update average_test.go to reflect new changes.